### PR TITLE
Fix WebProtégé merge workflow input filename

### DIFF
--- a/.github/workflows/webprotege-merge.yml
+++ b/.github/workflows/webprotege-merge.yml
@@ -35,7 +35,7 @@ jobs:
           if [ -f webprotege-export.zip ]; then
             WP_INPUT=webprotege-export.zip
           else
-            WP_INPUT=FOLIO-webprotege-merge.owl
+            WP_INPUT=FOLIO-webprotege-merge-output.owl
           fi
           python scripts/generate_webprotege_merge.py \
             --github-owl FOLIO.owl \


### PR DESCRIPTION
## Summary

The `WebProtégé Merge` workflow was failing on every push to `main` that touched `FOLIO.owl` (e.g. the merge of PR #10, run [24716808080](https://github.com/alea-institute/FOLIO/actions/runs/24716808080)) with `Process completed with exit code 1`.

Root cause: the `Run merge pipeline` step falls back to `FOLIO-webprotege-merge.owl` when no export zip is supplied, but that file was never committed — only `FOLIO-webprotege-merge-output.owl` exists (added in a4f22a3). The script raised `FileNotFoundError`.

Fix: point the fallback at the file that actually exists, so each run uses the previously-committed output as the base for the next iterative merge.

## Test plan

- [x] Reproduced the `FileNotFoundError` locally against `main`
- [x] Re-ran the script with the corrected input — pipeline completes, output validated as XML + RDF, 56 changes applied
- [ ] Confirm the next push to `main` touching `FOLIO.owl` runs the workflow to green

https://claude.ai/code/session_01NQ3iwytm4frS68Uj91wndu